### PR TITLE
feat(WIP): start to flesh out download survey metadata

### DIFF
--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -248,6 +248,7 @@
 
 {% block sidebar %}
 {% if release.live %}
+    {# {{ render_bundle('request_download', defer=True) }} #}
     <a id="releaseDownload" class='btn btn-primary my-1 w-100' data-name="download" rel='nofollow' href="{{ release.get_download_url() }}">
         <i class='fas fa-download'></i> Download Version {{ release.version_number }}
     </a>

--- a/django/library/models.py
+++ b/django/library/models.py
@@ -1367,6 +1367,10 @@ class CodebaseRelease(index.Indexed, ClusterableModel):
 
     @transaction.atomic
     def record_download(self, request):
+        """
+        FIXME: remove this method + dependencies when
+        DownloadRequestSerializer is finished
+        """
         referrer = request.META.get("HTTP_REFERER", "")
         client_ip, is_routable = get_client_ip(request)
         user = request.user if request.user.is_authenticated else None

--- a/django/library/serializers.py
+++ b/django/library/serializers.py
@@ -26,6 +26,7 @@ from .models import (
     ReleaseContributor,
     Codebase,
     CodebaseRelease,
+    CodebaseReleaseDownload,
     Contributor,
     License,
     CodebaseImage,
@@ -418,6 +419,14 @@ class CodebaseImageSerializer(serializers.ModelSerializer):
         model = CodebaseImage
         fields = ("identifier", "name", "file")
         extra_kwargs = {"file": {"write_only": True}}
+
+
+class DownloadRequestSerializer(serializers.ModelSerializer):
+    # customize save functionality to validate and record a new CodebaseReleaseDownload
+
+    class Meta:
+        model = CodebaseReleaseDownload
+        fields = ("referrer", "industry", "affiliation", "reason", "client_ip")
 
 
 class CodebaseReleaseSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
move CodebaseRelease.record_download logic into request_download API
endpoint and DownloadRequestSerializer

add a Vue modal to replace current Download button / link in the
retrieve page

refactor Edit.vue and move to compononents/